### PR TITLE
Extended canary testing

### DIFF
--- a/lib/System/Sub.pm
+++ b/lib/System/Sub.pm
@@ -179,9 +179,10 @@ sub _build_sub
                     push @output, $output_cb->($_)
                 }
             } else {
-                while (my $x = <$out>) {
-                    chomp $x;
-                    push @output, $x
+                local $_;
+                while (<$out>) {
+                    chomp;
+                    push @output, $_
                 }
             }
             close $out;

--- a/t/20-hostname.t
+++ b/t/20-hostname.t
@@ -15,6 +15,7 @@ my $got = hostname;
 is($got, $expected, 'scalar context');
 is($_, 'canary', '$_ not changed');
 
+$_ = 'canary';
 my @got = hostname;
 is_deeply(\@got, [ $expected ], 'list context');
 is($_, 'canary', '$_ not changed');

--- a/t/21-AUTOLOAD.t
+++ b/t/21-AUTOLOAD.t
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 
-use Test::More (-x '/bin/hostname' ? (tests => 2)
+use Test::More (-x '/bin/hostname' ? (tests => 3)
                                    : (skip_all => 'No /bin/hostname'));
 
 {
@@ -16,7 +16,9 @@ chomp $expected;
 my $got = cmd::hostname();
 is($got, $expected, 'scalar context');
 
+$_ = 'canary';
 my @got = cmd::hostname();
 is_deeply(\@got, [ $expected ], 'list context');
+is( $_, 'canary', '$_ not changed' );
 
 # vim:set et sw=4 sts=4:

--- a/t/22-ENV.t
+++ b/t/22-ENV.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 2;
+use Test::More tests => 3;
 use File::Spec;
 
 use System::Sub printenv => [ 0 => $^X,
@@ -13,6 +13,8 @@ use System::Sub printenv => [ 0 => $^X,
                             ];
 
 is(scalar printenv('Toto'), 'Titi', 'scalar context');
+$_ = 'canary';
 is_deeply([ printenv(qw(Toto Lala)) ], [ qw(Titi Lulu) ], 'list context');
+is( $_, 'canary', '$_ not changed' );
 
 # vim:set et sw=4 sts=4:


### PR DESCRIPTION
While trying to fix the issue in RT #118114, I wrote these tests.

The change to System::Sub itself is to bring back the previous version of the code while protecting $_ in the exact same way used in the other two instances.
